### PR TITLE
Revalidate field after a new value has been assigned

### DIFF
--- a/static/js/app/survey.js
+++ b/static/js/app/survey.js
@@ -919,7 +919,7 @@ define(['jquery', 'bootbox', 'survey.sum', 'survey.cell', 'surveys.dispatch', 'b
                 $('.survey-popover').tooltip();
                 $('input').placeholder();
 
-                sum.init();
+                sum.init(survey.form());
                 initDropdown();
                 initProgress();
 

--- a/static/js/app/survey/sum.js
+++ b/static/js/app/survey/sum.js
@@ -1,4 +1,7 @@
 define(['jquery', 'bootbox', 'survey.cell'], function($, bootbox, cell) {
+
+    var theForm = null;
+
     var sumOf = function (elements) {
         var sum = null;
 
@@ -89,6 +92,8 @@ define(['jquery', 'bootbox', 'survey.cell'], function($, bootbox, cell) {
                     // Clear subfields and put focus on sum field
                     $.each(childels, function (index, child) {
                         child.val("-");
+                        // revalidate to make sure we get rid of any error messages caused by previous value
+                        theForm.bootstrapValidator('revalidateField', child.prop('name'));
                     });
                     $(parent).focus()
                 } else {
@@ -106,7 +111,8 @@ define(['jquery', 'bootbox', 'survey.cell'], function($, bootbox, cell) {
     };
 
     return {
-        'init': function() {
+        'init': function(form) {
+            theForm = form;
             $.each($('input[data-sum-of]'), function() {
 
                 var parent = $(this);


### PR DESCRIPTION
Issue: 
When field values are changed programmatically, they are not being revalidated.
It is confusing to the user that a field shows validation error, despite it's value being correct.
Solution: 
Trigger field revalidation when value is changed by the script.