### PR TITLE
Add more logging

### DIFF
--- a/libstat/forms/survey.py
+++ b/libstat/forms/survey.py
@@ -187,10 +187,10 @@ class SurveyForm(forms.Form):
         if isinstance(field.initial, str):
             field.initial = field.initial.strip()
 
-        if cell.variable_key == "Besok01":
-            logger.debug("attrs:")
-            for attr, value in list(attrs.items()):
-                logger.debug(attr)
+        #if cell.variable_key == "Besok01":
+        #    logger.debug("attrs:")
+        #    for attr, value in list(attrs.items()):
+        #        logger.debug(attr)
 
         return field
 

--- a/libstat/utils.py
+++ b/libstat/utils.py
@@ -1,5 +1,6 @@
-# -*- coding: UTF-8 -*-
 import datetime
+
+from ipware import IpWare
 
 ALL_TARGET_GROUPS_label = "Samtliga bibliotek"
 SURVEY_TARGET_GROUPS = (
@@ -68,6 +69,8 @@ DATA_IMPORT_nonMeasurementCategories = [
 
 ISO8601_utc_format = "%Y-%m-%dT%H:%M:%S.%fZ"
 
+ipw = IpWare()
+
 
 def parse_datetime_from_isodate_str(date_str):
     # Note: Timezone designator not supported ("+01:00").
@@ -95,3 +98,23 @@ def parse_datetime(date_str, date_format):
         return datetime.datetime.strptime(date_str, date_format)
     except ValueError:
         return None
+
+
+def get_ip_for_logging(request):
+    # We use ipware (ipw) tp easily get the "real" client IP.
+    # Might need some adjustments depending on the environment, e.g. specifying
+    # trusted proxies.
+    # This is *ONLY* for logging purposes.
+    ip, trusted_route = ipw.get_client_ip(request.META)
+    return ip
+
+
+def get_log_prefix(request, survey_id=None, survey_title=None):
+    log_prefix = f"[IP: {get_ip_for_logging(request)}]"
+    if request.user.is_superuser:
+        log_prefix = f"{log_prefix} [ADMIN]"
+    if survey_id:
+        log_prefix = f"{log_prefix} [survey: {survey_id}]"
+    if survey_title:
+        log_prefix = f"{log_prefix} [{survey_title}]"
+    return log_prefix

--- a/libstat/views/dispatches.py
+++ b/libstat/views/dispatches.py
@@ -8,6 +8,7 @@ from django.template.loader import render_to_string
 
 from bibstat import settings
 from libstat.models import Dispatch, Survey
+from libstat.utils import get_log_prefix
 
 logger = logging.getLogger(__name__)
 
@@ -35,6 +36,7 @@ def _rendered_template(template, survey):
 def dispatches(request):
     if request.method == "POST":
         survey_ids = request.POST.getlist("survey-response-ids", [])
+        logger.info(f"{get_log_prefix(request)} Creating dispatches for {survey_ids}")
         surveys = list(Survey.objects.filter(id__in=survey_ids).exclude("observations"))
 
         dispatches = [
@@ -67,6 +69,7 @@ def dispatches(request):
 def dispatches_delete(request):
     if request.method == "POST":
         dispatch_ids = request.POST.getlist("dispatch-ids", [])
+        logger.info(f"{get_log_prefix(request)} Deleting dispatches {dispatch_ids}")
         Dispatch.objects.filter(id__in=dispatch_ids).delete()
 
         message = ""
@@ -83,6 +86,7 @@ def dispatches_delete(request):
 def dispatches_send(request):
     if request.method == "POST":
         dispatch_ids = request.POST.getlist("dispatch-ids", [])
+        logger.info(f"{get_log_prefix(request)} Sending dispatches {dispatch_ids}")
         dispatches = Dispatch.objects.filter(id__in=dispatch_ids)
         dispatches_with_email = [
             dispatch for dispatch in dispatches if dispatch.library_email

--- a/requirements.txt
+++ b/requirements.txt
@@ -15,3 +15,4 @@ urllib3==1.26.18
 certifi==2023.7.22
 black==22.6.0
 gunicorn==20.1.0
+python-ipware==1.0.5


### PR DESCRIPTION
Log various survey actions so that we have a better chance of identifying problems next time around.

Will need a separate PR in devops to log Django/gunicorn output to a file on disk that can be kept around for a while.